### PR TITLE
Specify protocol to correctly retrieve URL

### DIFF
--- a/basics.js
+++ b/basics.js
@@ -34,7 +34,7 @@ var config = require('./config'),
     };
 
 function getPictureFromEmail(email) {
-    return gravatar.url(email, config.gravatar);
+    return gravatar.url(email, config.gravatar, 'https');
 }
 
 function getUrlForPicture(resume) {


### PR DESCRIPTION
Generating the resume using some themes do not work properly.
As the protocol is not specified, the generated HTML will try to load
the picture in disk instead over https.
